### PR TITLE
Ensure "active" styles not added on first open

### DIFF
--- a/src/popup.ts
+++ b/src/popup.ts
@@ -86,7 +86,7 @@ async function showStatus() {
 	chrome.action.setIcon({
 		path: `icons/typex-${extensionActive ? "active" : "off"}@128.png`
 	});
-	activateFonts.classList.toggle("active", extensionActive);
+	activateFonts.classList.toggle("active", !!extensionActive);
 }
 
 // Toggle extension on/off using the button


### PR DESCRIPTION
This doesn’t include `npm run build`, as that provides more file change noise, but this seems to solve the problem of the incorrect "active" styling on first open.